### PR TITLE
Copy "either" result pattern from threads proposal

### DIFF
--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -36,6 +36,7 @@ and result' =
   | NumResult of num_pat
   | VecResult of vec_pat
   | RefResult of ref_pat
+  | EitherResult of result list
 
 type assertion = assertion' Source.phrase
 and assertion' =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -737,11 +737,12 @@ let ref_pat = function
   | RefPat r -> ref_ r.it
   | RefTypePat t -> Node ("ref." ^ refed_type t, [])
 
-let result mode res =
+let rec result mode res =
   match res.it with
   | NumResult np -> num_pat mode np
   | VecResult vp -> vec_pat mode vp
   | RefResult rp -> ref_pat rp
+  | EitherResult ress -> Node ("either", List.map (result mode) ress)
 
 let assertion mode ass =
   match ass.it with

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -480,6 +480,7 @@ rule token = parse
   | "assert_exhaustion" { ASSERT_EXHAUSTION }
   | "nan:canonical" { NAN Script.CanonicalNan }
   | "nan:arithmetic" { NAN Script.ArithmeticNan }
+  | "either" { EITHER }
   | "input" { INPUT }
   | "output" { OUTPUT }
 

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -227,7 +227,7 @@ let inline_type_explicit (c : context) x ft at =
 %token SCRIPT REGISTER INVOKE GET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_SOFT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_TRAP ASSERT_EXHAUSTION
-%token NAN
+%token NAN EITHER
 %token INPUT OUTPUT
 %token EOF
 
@@ -1157,7 +1157,8 @@ result :
     if V128.num_lanes $3 <> List.length $4 then
       error (at ()) "wrong number of lane literals";
     VecResult (VecPat (Values.V128 ($3, List.map (fun lit -> lit $3) $4))) @@ at ()
-  }
+    }
+  | LPAR EITHER result result_list RPAR { EitherResult ($3 :: $4) @@ at () }
 
 result_list :
   | /* empty */ { [] }


### PR DESCRIPTION
"either" allows us to assert that the a value is in a set of expected
values. This is copied from threads proposal and updated accordingly
to compile.

For #54.