### PR TITLE
Implement relaxed instructions using the non-relaxed counterpart 

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -772,6 +772,26 @@ let rec instr s =
     | 0xfdl -> i32x4_trunc_sat_f64x2_u_zero
     | 0xfel -> f64x2_convert_low_i32x4_s
     | 0xffl -> f64x2_convert_low_i32x4_u
+    | 0x100l -> i8x16_relaxed_swizzle
+    | 0x101l -> i32x4_relaxed_trunc_f32x4_s
+    | 0x102l -> i32x4_relaxed_trunc_f32x4_u
+    | 0x103l -> i32x4_relaxed_trunc_f64x2_s_zero
+    | 0x104l -> i32x4_relaxed_trunc_f64x2_u_zero
+    | 0x105l -> f32x4_relaxed_madd
+    | 0x106l -> f32x4_relaxed_nmadd
+    | 0x107l -> f64x2_relaxed_madd
+    | 0x108l -> f64x2_relaxed_nmadd
+    | 0x109l -> i8x16_relaxed_laneselect
+    | 0x10al -> i16x8_relaxed_laneselect
+    | 0x10bl -> i32x4_relaxed_laneselect
+    | 0x10cl -> i64x2_relaxed_laneselect
+    | 0x10dl -> f32x4_relaxed_min
+    | 0x10el -> f32x4_relaxed_max
+    | 0x10fl -> f64x2_relaxed_min
+    | 0x110l -> f64x2_relaxed_max
+    | 0x111l -> i16x8_relaxed_q15mulr_s
+    | 0x112l -> i16x8_relaxed_dot_i8x16_i7x16_s
+    | 0x113l -> i32x4_relaxed_dot_i8x16_i7x16_add_s
     | n -> illegal s pos (I32.to_int_u n)
     )
 

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -538,6 +538,10 @@ let rec step (c : config) : config =
         (try Vec (Eval_vec.eval_binop binop n1 n2) :: vs', []
         with exn -> vs', [Trapping (numeric_error e.at exn) @@ e.at])
 
+      | VecTernary ternop, Vec v3 :: Vec v2 :: Vec v1 :: vs' ->
+        (try Vec (Eval_vec.eval_ternop ternop v1 v2 v3) :: vs', []
+        with exn -> vs', [Trapping (numeric_error e.at exn) @@ e.at])
+
       | VecCompare relop, Vec n2 :: Vec n1 :: vs' ->
         (try Vec (Eval_vec.eval_relop relop n1 n2) :: vs', []
         with exn -> vs', [Trapping (numeric_error e.at exn) @@ e.at])

--- a/interpreter/exec/eval_vec.ml
+++ b/interpreter/exec/eval_vec.ml
@@ -128,9 +128,9 @@ struct
   let ternop (op : ternop) =
     let f = match op with
       | F32x4 RelaxedMadd -> V128.F32x4.fma
-      | F32x4 RelaxedNmadd -> V128.F32x4.fms
+      | F32x4 RelaxedNmadd -> V128.F32x4.fnma
       | F64x2 RelaxedMadd -> V128.F64x2.fma
-      | F64x2 RelaxedNmadd -> V128.F64x2.fms
+      | F64x2 RelaxedNmadd -> V128.F64x2.fnma
       | I8x16 RelaxedLaneselect -> V128.V1x128.bitselect
       | I16x8 RelaxedLaneselect -> V128.V1x128.bitselect
       | I32x4 RelaxedLaneselect -> V128.V1x128.bitselect

--- a/interpreter/exec/eval_vec.ml
+++ b/interpreter/exec/eval_vec.ml
@@ -61,6 +61,7 @@ struct
       | I8x16 MaxS -> V128.I8x16.max_s
       | I8x16 MaxU -> V128.I8x16.max_u
       | I8x16 AvgrU -> V128.I8x16.avgr_u
+      | I8x16 RelaxedSwizzle -> V128.V8x16.swizzle
       | I16x8 NarrowS -> V128.I16x8_convert.narrow_s
       | I16x8 NarrowU -> V128.I16x8_convert.narrow_u
       | I16x8 Add -> V128.I16x8.add
@@ -80,6 +81,8 @@ struct
       | I16x8 ExtMulLowU -> V128.I16x8_convert.extmul_low_u
       | I16x8 ExtMulHighU -> V128.I16x8_convert.extmul_high_u
       | I16x8 Q15MulRSatS -> V128.I16x8.q15mulr_sat_s
+      | I16x8 RelaxedQ15MulRS -> V128.I16x8.q15mulr_sat_s
+      | I16x8 RelaxedDot -> V128.I16x8_convert.dot_s
       | I32x4 Add -> V128.I32x4.add
       | I32x4 Sub -> V128.I32x4.sub
       | I32x4 MinS -> V128.I32x4.min_s
@@ -107,6 +110,8 @@ struct
       | F32x4 Max -> V128.F32x4.max
       | F32x4 Pmin -> V128.F32x4.pmin
       | F32x4 Pmax -> V128.F32x4.pmax
+      | F32x4 RelaxedMin -> V128.F32x4.min
+      | F32x4 RelaxedMax -> V128.F32x4.max
       | F64x2 Add -> V128.F64x2.add
       | F64x2 Sub -> V128.F64x2.sub
       | F64x2 Mul -> V128.F64x2.mul
@@ -115,8 +120,24 @@ struct
       | F64x2 Max -> V128.F64x2.max
       | F64x2 Pmin -> V128.F64x2.pmin
       | F64x2 Pmax -> V128.F64x2.pmax
+      | F64x2 RelaxedMin -> V128.F64x2.min
+      | F64x2 RelaxedMax -> V128.F64x2.max
       | _ -> assert false
     in fun v1 v2 -> to_vec (f (of_vec 1 v1) (of_vec 2 v2))
+
+  let ternop (op : ternop) =
+    let f = match op with
+      | F32x4 RelaxedMadd -> V128.F32x4.fma
+      | F32x4 RelaxedNmadd -> V128.F32x4.fms
+      | F64x2 RelaxedMadd -> V128.F64x2.fma
+      | F64x2 RelaxedNmadd -> V128.F64x2.fms
+      | I8x16 RelaxedLaneselect -> V128.V1x128.bitselect
+      | I16x8 RelaxedLaneselect -> V128.V1x128.bitselect
+      | I32x4 RelaxedLaneselect -> V128.V1x128.bitselect
+      | I64x2 RelaxedLaneselect -> V128.V1x128.bitselect
+      | I32x4 RelaxedDotAccum -> V128.I32x4_convert.dot_s_accum
+      | _ -> assert false
+    in fun v1 v2 v3 -> to_vec (f (of_vec 1 v1) (of_vec 2 v2) (of_vec 3 v3))
 
   let relop (op : relop) =
     let f = match op with
@@ -187,6 +208,10 @@ struct
       | I32x4 TruncSatUF32x4 -> V128.I32x4_convert.trunc_sat_f32x4_u
       | I32x4 TruncSatSZeroF64x2 -> V128.I32x4_convert.trunc_sat_f64x2_s_zero
       | I32x4 TruncSatUZeroF64x2 -> V128.I32x4_convert.trunc_sat_f64x2_u_zero
+      | I32x4 RelaxedTruncSF32x4 -> V128.I32x4_convert.trunc_sat_f32x4_s
+      | I32x4 RelaxedTruncUF32x4 -> V128.I32x4_convert.trunc_sat_f32x4_u
+      | I32x4 RelaxedTruncSZeroF64x2 -> V128.I32x4_convert.trunc_sat_f64x2_s_zero
+      | I32x4 RelaxedTruncUZeroF64x2 -> V128.I32x4_convert.trunc_sat_f64x2_u_zero
       | I32x4 ExtAddPairwiseS -> V128.I32x4_convert.extadd_pairwise_s
       | I32x4 ExtAddPairwiseU -> V128.I32x4_convert.extadd_pairwise_u
       | I64x2 ExtendLowS -> V128.I64x2_convert.extend_low_s
@@ -301,6 +326,7 @@ let op v128 = function
 let eval_testop = op V128Op.testop
 let eval_unop = op V128Op.unop
 let eval_binop = op V128Op.binop
+let eval_ternop = op V128Op.ternop
 let eval_relop = op V128Op.relop
 let eval_cvtop = op V128Op.cvtop
 let eval_shiftop = op V128Op.shiftop

--- a/interpreter/exec/eval_vec.mli
+++ b/interpreter/exec/eval_vec.mli
@@ -3,6 +3,7 @@ open Values
 val eval_testop : Ast.vec_testop -> vec -> bool
 val eval_unop : Ast.vec_unop -> vec -> vec
 val eval_binop : Ast.vec_binop -> vec -> vec -> vec
+val eval_ternop : Ast.vec_ternop -> vec -> vec -> vec -> vec
 val eval_relop : Ast.vec_relop -> vec -> vec -> vec
 val eval_cvtop : Ast.vec_cvtop -> vec -> vec
 val eval_shiftop : Ast.vec_shiftop -> vec -> num -> vec

--- a/interpreter/exec/fxx.ml
+++ b/interpreter/exec/fxx.ml
@@ -43,6 +43,7 @@ sig
   val sub : t -> t -> t
   val mul : t -> t -> t
   val div : t -> t -> t
+  val fma : t -> t -> t -> t
   val sqrt : t -> t
   val min : t -> t -> t
   val max : t -> t -> t
@@ -137,6 +138,12 @@ struct
   let sub x y = binary x (-.) y
   let mul x y = binary x ( *.) y
   let div x y = binary x (/.) y
+  let fma x y z =
+    let xf = to_float x in
+    let yf = to_float y in
+    let zf = to_float z in
+    let t = Float.fma xf yf zf in
+    if t = t then of_float t else determine_binary_nan x y
 
   let sqrt  x = unary Stdlib.sqrt x
 

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -433,11 +433,11 @@ struct
     let ys = I8x16.to_lanes y in
     let rec dot xs ys =
       match xs, ys with
-      | x1::x2::x3::x4::xss, y1::y2::y3::y4::yss ->
-          Int32.(add
-            (add (mul x1 y1) (mul x2 y2))
-            (add (mul x3 y3) (mul x4 y4)))
-          :: dot xss yss
+      | x1::x2::x3::x4::xs', y1::y2::y3::y4::ys' ->
+        Int32.(add
+          (add (mul x1 y1) (mul x2 y2))
+          (add (mul x3 y3) (mul x4 y4)))
+        :: dot xs' ys'
       | [], [] -> []
       | _, _ -> assert false
     in I32x4.add (I32x4.of_lanes (dot xs ys)) z

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -192,7 +192,7 @@ sig
   val mul : t -> t -> t
   val div : t -> t -> t
   val fma : t -> t -> t -> t
-  val fms : t -> t -> t -> t
+  val fnma : t -> t -> t -> t
   val min : t -> t -> t
   val max : t -> t -> t
   val pmin : t -> t -> t
@@ -242,7 +242,7 @@ struct
       | [], [], [] -> []
       | _ -> assert false
     in of_lanes (fma_iter (to_lanes x) (to_lanes y) (to_lanes z))
-  let fms x y z = fma x y (unop FXX.neg z)
+  let fnma x y z = fma x y (unop FXX.neg z)
   let min = binop FXX.min
   let max = binop FXX.max
   let pmin = binop (fun x y -> if FXX.lt y x then y else x)

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -236,12 +236,7 @@ struct
   let mul = binop FXX.mul
   let div = binop FXX.div
   let fma x y z =
-    let rec fma_iter xs ys zs : FXX.t list =
-      match xs, ys, zs with
-      | x::xss, y::yss, z::zss -> (FXX.fma x y z) :: (fma_iter xss yss zss)
-      | [], [], [] -> []
-      | _ -> assert false
-    in of_lanes (fma_iter (to_lanes x) (to_lanes y) (to_lanes z))
+    of_lanes (Lib.List.map3 FXX.fma (to_lanes x) (to_lanes y) (to_lanes z))
   let fnma x y z = fma (unop FXX.neg x) y z
   let min = binop FXX.min
   let max = binop FXX.max

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -242,7 +242,7 @@ struct
       | [], [], [] -> []
       | _ -> assert false
     in of_lanes (fma_iter (to_lanes x) (to_lanes y) (to_lanes z))
-  let fnma x y z = fma x y (unop FXX.neg z)
+  let fnma x y z = fma (unop FXX.neg x) y z
   let min = binop FXX.min
   let max = binop FXX.max
   let pmin = binop (fun x y -> if FXX.lt y x then y else x)

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -389,8 +389,8 @@ struct
     let ys = I8x16.to_lanes y in
     let rec dot xs ys =
       match xs, ys with
-      | x1::x2::xss, y1::y2::yss ->
-        Int32.(add (mul x1 y1) (mul x2 y2)) :: dot xss yss
+      | x1::x2::xs', y1::y2::ys' ->
+        Int32.(add (mul x1 y1) (mul x2 y2)) :: dot xs' ys'
       | [], [] -> []
       | _, _ -> assert false
     in I16x8.of_lanes (dot xs ys)

--- a/interpreter/exec/v128.mli
+++ b/interpreter/exec/v128.mli
@@ -108,6 +108,8 @@ sig
   val sub : t -> t -> t
   val mul : t -> t -> t
   val div : t -> t -> t
+  val fma : t -> t -> t -> t
+  val fms : t -> t -> t -> t
   val min : t -> t -> t
   val max : t -> t -> t
   val pmin : t -> t -> t
@@ -163,6 +165,7 @@ sig
   val extmul_high_u : t -> t -> t
   val extadd_pairwise_s : t -> t
   val extadd_pairwise_u : t -> t
+  val dot_s : t -> t -> t
 end
 
 module I32x4_convert :
@@ -176,6 +179,7 @@ sig
   val extend_low_u : t -> t
   val extend_high_u : t -> t
   val dot_s : t -> t -> t
+  val dot_s_accum : t -> t -> t -> t
   val extmul_low_s : t -> t -> t
   val extmul_high_s : t -> t -> t
   val extmul_low_u : t -> t -> t

--- a/interpreter/exec/v128.mli
+++ b/interpreter/exec/v128.mli
@@ -109,7 +109,7 @@ sig
   val mul : t -> t -> t
   val div : t -> t -> t
   val fma : t -> t -> t -> t
-  val fms : t -> t -> t -> t
+  val fnma : t -> t -> t -> t
   val min : t -> t -> t
   val max : t -> t -> t
   val pmin : t -> t -> t

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -265,7 +265,7 @@ struct
 
   let iternop xxxx (op : iternop) = match op with
     | RelaxedLaneselect -> "relaxed_laneselect"
-    | RelaxedDotAccum -> "relaxed_dot_i" ^ half (half xxxx) ^ "_i" ^ without_high_bit (half (half xxxx)) ^ "add_s"
+    | RelaxedDotAccum -> "relaxed_dot_i" ^ half (half xxxx) ^ "_i" ^ without_high_bit (half (half xxxx)) ^ "_add_s"
 
   let fbinop xxxx (op : fbinop) = match op with
     | Add -> "add"

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -105,6 +105,12 @@ struct
       | None -> map_filter f xs
       | Some y -> y :: map_filter f xs
 
+  let rec map3 f xs ys zs =
+    match xs, ys, zs with
+    | [], [], [] -> []
+    | x::xs', y::ys', z::zs' -> f x y z :: map3 f xs' ys' zs'
+    | _ -> assert false
+
   let rec concat_map f = function
     | [] -> []
     | x::xs -> f x @ concat_map f xs

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -109,7 +109,7 @@ struct
     match xs, ys, zs with
     | [], [], [] -> []
     | x::xs', y::ys', z::zs' -> f x y z :: map3 f xs' ys' zs'
-    | _ -> assert false
+    | _ -> raise (Invalid_argument "Lib.List.map3")
 
   let rec concat_map f = function
     | [] -> []

--- a/interpreter/util/lib.mli
+++ b/interpreter/util/lib.mli
@@ -24,6 +24,7 @@ sig
   val index_of : 'a -> 'a list -> int option
   val index_where : ('a -> bool) -> 'a list -> int option
   val map_filter : ('a -> 'b option) -> 'a list -> 'b list
+  val map3 : ('a -> 'b -> 'c -> 'd) -> 'a list -> 'b list -> 'c list -> 'd list
   val concat_map : ('a -> 'b list) -> 'a list -> 'b list
   val pairwise : ('a -> 'a -> 'b) -> 'a list -> 'b list
 end

--- a/test/core/run.py
+++ b/test/core/run.py
@@ -108,6 +108,9 @@ class RunTests(unittest.TestCase):
     self._compareFile(wastPath, wast2Path)
 
     if jsCommand != None:
+      if 'node' in jsCommand and 'relaxed-simd' in jsPath:
+        # node does not support relaxed-simd yet.
+        return
       self._runCommand(('%s "%s"') % (jsCommand, jsPath), logPath)
 
 

--- a/test/core/run.py
+++ b/test/core/run.py
@@ -26,12 +26,13 @@ sys.argv = sys.argv[:1]
 main_test_files = glob.glob(os.path.join(inputDir, "*.wast"))
 # SIMD test files are in a subdirectory.
 simd_test_files = glob.glob(os.path.join(inputDir, "simd", "*.wast"))
+relaxed_simd_test_files = glob.glob(os.path.join(inputDir, "relaxed-simd", "*.wast"))
 
 wasmCommand = arguments.wasm
 jsCommand = arguments.js
 generateJsOnly = arguments.generate_js_only
 outputDir = arguments.out
-inputFiles = arguments.file if arguments.file else main_test_files + simd_test_files
+inputFiles = arguments.file if arguments.file else main_test_files + simd_test_files + relaxed_simd_test_files
 
 if not os.path.exists(wasmCommand):
   sys.stderr.write("""\

--- a/test/core/run.py
+++ b/test/core/run.py
@@ -108,8 +108,8 @@ class RunTests(unittest.TestCase):
     self._compareFile(wastPath, wast2Path)
 
     if jsCommand != None:
+      # TODO: node does not support relaxed-simd yet.
       if 'node' in jsCommand and 'relaxed-simd' in jsPath:
-        # node does not support relaxed-simd yet.
         return
       self._runCommand(('%s "%s"') % (jsCommand, jsPath), logPath)
 


### PR DESCRIPTION
relaxed swizzle -> swizzle
relaxed trunc -> trunc sat
madd/nmadd -> fused multiply add/sub (1 rounding)
relaxed laneselect -> bitselect
relaxed min/max -> min/max
i16x8 q15mulr -> i16x8.q15mulr with sat
relaxed dot -> dot/simd128 fallback