### PR TITLE
Fix relaxed nmadd tests

### DIFF
--- a/test/core/relaxed-simd/relaxed_madd_nmadd.wast
+++ b/test/core/relaxed-simd/relaxed_madd_nmadd.wast
@@ -52,10 +52,18 @@
                        (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (either (v128.const f32x4 0x1p-37 0x1p-37 0x1p-37 0x1p-37)
                        (v128.const f32x4 0 0 0 0)))
+;; nmadd tests with x, same answers are expected.
+(assert_return (invoke "f32x4.relaxed_nmadd"
+                       (v128.const f32x4 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0)
+                       (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
+                       (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
+               (either (v128.const f32x4 0x1p-37 0x1p-37 0x1p-37 0x1p-37)
+                       (v128.const f32x4 0 0 0 0)))
+;; nmadd tests with y, same answers are expected.
 (assert_return (invoke "f32x4.relaxed_nmadd"
                        (v128.const f32x4 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0)
-                       (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
-                       (v128.const f32x4 0x1.000204p+0 0x1.000204p+0 0x1.000204p+0 0x1.000204p+0))
+                       (v128.const f32x4 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0)
+                       (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (either (v128.const f32x4 0x1p-37 0x1p-37 0x1p-37 0x1p-37)
                        (v128.const f32x4 0 0 0 0)))
 
@@ -87,10 +95,18 @@
                        (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (either (v128.const f64x2 0x1p-53 0x1p-53)
                        (v128.const f64x2 0 0)))
+;; nmadd tests with x, same answers are expected.
+(assert_return (invoke "f64x2.relaxed_nmadd"
+                       (v128.const f64x2 -0x1.00000004p+0 -0x1.00000004p+0)
+                       (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
+                       (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
+               (either (v128.const f64x2 0x1p-53 0x1p-53)
+                       (v128.const f64x2 0 0)))
+;; nmadd tests with y, same answers are expected.
 (assert_return (invoke "f64x2.relaxed_nmadd"
                        (v128.const f64x2 0x1.00000004p+0 0x1.00000004p+0)
-                       (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
-                       (v128.const f64x2 0x1.00000204p+0 0x1.00000204p+0))
+                       (v128.const f64x2 -0x1.000002p+0 -0x1.000002p+0)
+                       (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (either (v128.const f64x2 0x1p-53 0x1p-53)
                        (v128.const f64x2 0 0)))
 
@@ -121,10 +137,17 @@
                        (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
                        (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (v128.const i32x4 -1 -1 -1 -1))
+;; nmadd tests with x, same answers are expected.
+(assert_return (invoke "f32x4.relaxed_nmadd_cmp"
+                       (v128.const f32x4 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0)
+                       (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
+                       (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
+               (v128.const i32x4 -1 -1 -1 -1))
+;; nmadd tests with y, same answers are expected.
 (assert_return (invoke "f32x4.relaxed_nmadd_cmp"
                        (v128.const f32x4 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0)
-                       (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
-                       (v128.const f32x4 0x1.000204p+0 0x1.000204p+0 0x1.000204p+0 0x1.000204p+0))
+                       (v128.const f32x4 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0)
+                       (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (v128.const i32x4 -1 -1 -1 -1))
 
 ;; DBL_MAX = 0x1.fffffffffffffp+1023
@@ -153,8 +176,15 @@
                        (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
                        (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (v128.const i64x2 -1 -1))
+;; nmadd tests with x, same answers are expected.
+(assert_return (invoke "f64x2.relaxed_nmadd_cmp"
+                       (v128.const f64x2 -0x1.00000004p+0 -0x1.00000004p+0)
+                       (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
+                       (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
+               (v128.const i64x2 -1 -1))
+;; nmadd tests with y, same answers are expected.
 (assert_return (invoke "f64x2.relaxed_nmadd_cmp"
                        (v128.const f64x2 0x1.00000004p+0 0x1.00000004p+0)
-                       (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
-                       (v128.const f64x2 0x1.00000204p+0 0x1.00000204p+0))
+                       (v128.const f64x2 -0x1.000002p+0 -0x1.000002p+0)
+                       (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (v128.const i64x2 -1 -1))

--- a/test/core/relaxed-simd/relaxed_madd_nmadd.wast
+++ b/test/core/relaxed-simd/relaxed_madd_nmadd.wast
@@ -52,14 +52,14 @@
                        (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (either (v128.const f32x4 0x1p-37 0x1p-37 0x1p-37 0x1p-37)
                        (v128.const f32x4 0 0 0 0)))
-;; nmadd tests with x, same answers are expected.
+;; nmadd tests with negated x, same answers are expected.
 (assert_return (invoke "f32x4.relaxed_nmadd"
                        (v128.const f32x4 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0)
                        (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
                        (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (either (v128.const f32x4 0x1p-37 0x1p-37 0x1p-37 0x1p-37)
                        (v128.const f32x4 0 0 0 0)))
-;; nmadd tests with y, same answers are expected.
+;; nmadd tests with negated y, same answers are expected.
 (assert_return (invoke "f32x4.relaxed_nmadd"
                        (v128.const f32x4 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0)
                        (v128.const f32x4 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0)
@@ -95,14 +95,14 @@
                        (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (either (v128.const f64x2 0x1p-53 0x1p-53)
                        (v128.const f64x2 0 0)))
-;; nmadd tests with x, same answers are expected.
+;; nmadd tests with negated x, same answers are expected.
 (assert_return (invoke "f64x2.relaxed_nmadd"
                        (v128.const f64x2 -0x1.00000004p+0 -0x1.00000004p+0)
                        (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
                        (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (either (v128.const f64x2 0x1p-53 0x1p-53)
                        (v128.const f64x2 0 0)))
-;; nmadd tests with y, same answers are expected.
+;; nmadd tests with negated y, same answers are expected.
 (assert_return (invoke "f64x2.relaxed_nmadd"
                        (v128.const f64x2 0x1.00000004p+0 0x1.00000004p+0)
                        (v128.const f64x2 -0x1.000002p+0 -0x1.000002p+0)
@@ -137,13 +137,13 @@
                        (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
                        (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (v128.const i32x4 -1 -1 -1 -1))
-;; nmadd tests with x, same answers are expected.
+;; nmadd tests with negated x, same answers are expected.
 (assert_return (invoke "f32x4.relaxed_nmadd_cmp"
                        (v128.const f32x4 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0 -0x1.000004p+0)
                        (v128.const f32x4 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0 0x1.0002p+0)
                        (v128.const f32x4 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0 -0x1.000204p+0))
                (v128.const i32x4 -1 -1 -1 -1))
-;; nmadd tests with y, same answers are expected.
+;; nmadd tests with negated y, same answers are expected.
 (assert_return (invoke "f32x4.relaxed_nmadd_cmp"
                        (v128.const f32x4 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0 0x1.000004p+0)
                        (v128.const f32x4 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0 -0x1.0002p+0)
@@ -176,13 +176,13 @@
                        (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
                        (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (v128.const i64x2 -1 -1))
-;; nmadd tests with x, same answers are expected.
+;; nmadd tests with negated x, same answers are expected.
 (assert_return (invoke "f64x2.relaxed_nmadd_cmp"
                        (v128.const f64x2 -0x1.00000004p+0 -0x1.00000004p+0)
                        (v128.const f64x2 0x1.000002p+0 0x1.000002p+0)
                        (v128.const f64x2 -0x1.00000204p+0 -0x1.00000204p+0))
                (v128.const i64x2 -1 -1))
-;; nmadd tests with y, same answers are expected.
+;; nmadd tests with negated y, same answers are expected.
 (assert_return (invoke "f64x2.relaxed_nmadd_cmp"
                        (v128.const f64x2 0x1.00000004p+0 0x1.00000004p+0)
                        (v128.const f64x2 -0x1.000002p+0 -0x1.000002p+0)


### PR DESCRIPTION
`nmadd(x, y, z) == nmadd(-x, y, z)`
the tests were doing `-z` instead.