### PR TITLE
Fix some tests in `i32x4_relaxed_trunc.wast`

### DIFF
--- a/test/core/relaxed-simd/i32x4_relaxed_trunc.wast
+++ b/test/core/relaxed-simd/i32x4_relaxed_trunc.wast
@@ -25,17 +25,17 @@
 )
 
 (assert_return (invoke "i32x4.relaxed_trunc_f32x4_s"
-                       ;; INT32_MIN <INT32_MIN INT32_MAX >INT32_MAX
-                       (v128.const f32x4 -2147483648.0 -2147483904.0 2147483647.0 2147483904.0))
+                       ;;                INT32_MIN     <INT32_MIN        >INT32_MAX
+                       (v128.const f32x4 -2147483648.0 -2147483904.0 2.0 2147483904.0))
                ;; out of range -> saturate or INT32_MIN
-               (either (v128.const i32x4 -2147483648 -2147483648 2147483647 2147483647)
-                       (v128.const i32x4 -2147483648 -2147483648 2147483647 -2147483648)))
+               (either (v128.const i32x4 -2147483648 -2147483648 2 2147483647)
+                       (v128.const i32x4 -2147483648 -2147483648 2 -2147483648)))
 
 (assert_return (invoke "i32x4.relaxed_trunc_f32x4_s"
                        (v128.const f32x4 nan -nan nan:0x444444 -nan:0x444444))
                ;; nans -> 0 or INT32_MIN
                (either (v128.const i32x4 0 0 0 0)
-                       (v128.const i32x4 0x8000000 0x8000000 0x8000000 0x8000000)))
+                       (v128.const i32x4 0x80000000 0x80000000 0x80000000 0x80000000)))
 
 (assert_return (invoke "i32x4.relaxed_trunc_f32x4_u"
                        ;; UINT32_MIN UINT32_MIN-1 <UINT32_MAX UINT32_MAX+1
@@ -59,7 +59,7 @@
 (assert_return (invoke "i32x4.relaxed_trunc_f64x2_s_zero"
                        (v128.const f64x2 nan -nan))
                (either (v128.const i32x4 0 0 0 0)
-                       (v128.const i32x4 0x8000000 0x8000000 0 0)))
+                       (v128.const i32x4 0x80000000 0x80000000 0 0)))
 
 (assert_return (invoke "i32x4.relaxed_trunc_f64x2_u_zero"
                        (v128.const f64x2 -1.0 4294967296.0))

--- a/test/core/relaxed-simd/i32x4_relaxed_trunc.wast
+++ b/test/core/relaxed-simd/i32x4_relaxed_trunc.wast
@@ -24,6 +24,14 @@
             (i32x4.relaxed_trunc_f64x2_u_zero (local.get 0))))
 )
 
+;; Test some edge cases around min/max to ensure that the instruction either
+;; saturates correctly or returns INT_MIN.
+;;
+;; Note, though, that INT_MAX itself is not tested. The value for INT_MAX is
+;; 2147483647 but that is not representable in a `f32` since it requires 31 bits
+;; when a f32 has only 24 bits available. This means that the closest integers
+;; to INT_MAX which can be represented are 2147483520 and 2147483648, meaning
+;; that the INT_MAX test case cannot be tested.
 (assert_return (invoke "i32x4.relaxed_trunc_f32x4_s"
                        ;;                INT32_MIN     <INT32_MIN        >INT32_MAX
                        (v128.const f32x4 -2147483648.0 -2147483904.0 2.0 2147483904.0))


### PR DESCRIPTION
This fixes some minor issues I encountered when running these tests. The first is a test for the `i32x4.relaxed_trunc_f32x4_s` instruction which asserted that `2147483647.0` (INT_MAX) would get translated to INT_MAX through the conversion. This float value, however, is not representable in `f32`. The two other closest integers that `f32` can represent are 2147483648 and 2147483520, so it's not actually possible to exercise a conversion from precisely INT_MAX to INT_MAX. Due to float parsing this meant that the value was getting rounded up to 2147483648 which exceeded INT_MAX which when using `cvttpd2dq` on x86 would cause INT_MIN to get returning, failing the test. I updated the test to pass something in-bounds (2 in this case) since the other edge cases are already tested.

The other issue fixed in this commit is that many tests asserted that INT_MIN was a possible result but the representation of INT_MIN was missing a 0 in its hexadecimal representation, so zeros were appended.