### PR TITLE
Fix relaxed laneselect to allow looking at top bit of byte

### DIFF
--- a/document/core/exec/numerics.rst
+++ b/document/core/exec/numerics.rst
@@ -2168,23 +2168,31 @@ The result for NaN's and out-of-range values is host-dependent.
 :math:`\relaxedlane_N(i_1, i_2, i_3)`
 .....................................
 
-* If :math:`i_3` is :math:`2^N - 1`, return :math:`i_1`.
+* :math:`\EXPROFDET` If :math:`i_3` is :math:`2^N - 1`, return :math:`i_1`.
 
-* Else if :math:`i_3` is :math:`0`, return :math:`i_2`.
+* :math:`\EXPROFDET` Else if :math:`i_3` is :math:`0`, return :math:`i_2`.
 
-* :math:`\EXPROFDET` Else if :math:`\signed_n(i_3)` is less than :math:`0`, return either :math:`\ibitselect_n(i_1, i_2, i_3)` or :math:`i_1`.
+* :math:`\EXPROFDET` Otherwise return either :math:`\ibitselect_n(i_1, i_2, i_3)` or :math:`i_1` or :math:`i_2` or :math:`\F{top\_bit\_byteselect_N}(i_1, i_2, i_3)`.
 
-* :math:`\EXPROFDET` Otherwise return either :math:`\ibitselect_n(i_1, i_2, i_3)` or :math:`i_2`.
-
-* Otherwise return :math:`\ibitselect_n(i_1, i_2, i_3)`.
+* Return :math:`\ibitselect_n(i_1, i_2, i_3)`.
 
 .. math::
    \begin{array}{@{}llcll}
-   & \relaxedlane_N(i_1, i_2, 2^N-1) &=& i_1 \\
-   & \relaxedlane_N(i_1, i_2, 0) &=& i_2 \\
-   \EXPROFDET & \relaxedlane_N(i_1, i_2, i_3) &=& [ \ibitselect_N(i_1, i_2, i_3), i_1 ] & (\iff \signed_N(i_3) < 0) \\
-   \EXPROFDET & \relaxedlane_N(i_1, i_2, i_3) &=& [ \ibitselect_N(i_1, i_2, i_3), i_2 ] & (\otherwise) \\
+   \EXPROFDET & \relaxedlane_N(i_1, i_2, 2^N-1) &=& i_1 \\
+   \EXPROFDET & \relaxedlane_N(i_1, i_2, 0) &=& i_2 \\
+   \EXPROFDET & \relaxedlane_N(i_1, i_2, i_3) &=& [ \ibitselect_N(i_1, i_2, i_3), i_2, i_3, \\
+    & & & \qquad \F{top\_bit\_byteselect}(i_1, i_2, i_3)] & (\otherwise) \\
    & \relaxedlane_N(i_1, i_2, i_3) &=& \ibitselect_N(i_1, i_2, i_3) & (\otherwise) \\
+   \end{array}
+
+where:
+
+.. math::
+   \begin{array}{@{}llcll}
+   & \F{top\_bit\_byteselect}_N(i_1, i_2, i_3) &=& tbb_0 ... tbb_{N/8 - 1} \\
+   & \F{tbb_j} &=& \F{byteselect}(\bytes_8(i_1)[j], \bytes_8(i_2)[j], \bytes_8(i_3)[j]) \\
+   & \F{byteselect}(a, b, 0~c^7) &=& a \\
+   & \F{byteselect}(a, b, c) &=& b \\
    \end{array}
 
 
@@ -2195,7 +2203,8 @@ The result for NaN's and out-of-range values is host-dependent.
 
 Relaxed lane selection is deterministic when all bits are set or unset in the
 mask. Otherwise depending on the host, either only the top bit is examined, or
-all bits are examined (i.e. it becomes a bit select).
+all bits are examined (i.e. it becomes a bit select), or the top bit of each
+byte in the lane is examined.
 
 * Return :math:`rll_0 \dots rll_{n-1}` where :math:`rll_i = \relaxedlane_B(a^n[i], b^n[i], c^n[i])`.
 

--- a/test/core/relaxed-simd/relaxed_laneselect.wast
+++ b/test/core/relaxed-simd/relaxed_laneselect.wast
@@ -38,6 +38,16 @@
                (either (v128.const i16x8 0      9 0x1278 0x5634 12 13 14 15)
                        (v128.const i16x8 0      9 0x1234 0x5678 12 13 14 15)))
 
+;; special case for i16x8 to allow pblendvb
+(assert_return (invoke "i16x8.relaxed_laneselect"
+                       (v128.const i16x8 0      1 0x1234 0x1234 4 5 6 7)
+                       (v128.const i16x8 8      9 0x5678 0x5678 12 13 14 15)
+                       (v128.const i16x8 0xffff 0 0xff00 0x0080 0 0 0 0))  ;; 0x0080 is the special case
+               (either (v128.const i16x8 0      9 0x1278 0x5678 12 13 14 15)  ;; bitselect
+                       (v128.const i16x8 0      9 0x1234 0x5678 12 13 14 15)  ;; top bit of i16 lane examined
+                       (v128.const i16x8 0      9 0x1278 0x5634 12 13 14 15)  ;; top bit of each byte
+                       ))
+
 (assert_return (invoke "i32x4.relaxed_laneselect"
                        (v128.const i32x4 0          1 0x12341234 0x12341234)
                        (v128.const i32x4 4          5 0x56785678 0x56785678)


### PR DESCRIPTION
This allows using pblendvb for i16x8 lane select. See #125.